### PR TITLE
tests: add more tests from scipy test suite (claude)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### ✨ Features
+
+- CMake install/export support: `find_package(lsoda CONFIG)`, `FetchContent`, and `add_subdirectory` all work with the unified `lsoda::lsoda` target
+- Integration test: CTest step that installs the library and builds a standalone consumer via `find_package`
+
+### 🐛 Bug Fixes
+
+- Fixed inconsistent `#include` spelling between build-tree and install-tree consumers (`#include <lsoda/LSODA.h>` now works for all integration patterns)
+- Replaced `assert()` checks in tests with a `CHECK` macro that is active in Release builds (`assert` is a no-op when `NDEBUG` is defined)
+
+### 📚 Documentation
+
+- Updated README with usage example, build instructions, and all three CMake integration patterns
+- Added `CLAUDE.md` with build commands and architecture notes
+
+### 🧪 Tests
+
+- Added four ODE unit tests ported from SciPy's test suite: exponential decay, simple harmonic oscillator, coupled radioactive decay (Bateman equations), and rational ODE — each verified against an analytical solution
+
 ## [0.1.1] - 2025-06-05
 
 ### ⚙️ Miscellaneous Tasks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`libsoda-cxx` is a C++17 port of the LSODA ODE solver library (originally from Heng Li's C implementation). LSODA automatically switches between Adams (non-stiff) and BDF (stiff) methods with adaptive step size and order selection.
+
+## Build Commands
+
+```bash
+# Configure and build
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+
+# Run tests
+cd build && ctest
+
+# Run a single test executable directly
+./build/test_lsoda
+
+# Run benchmarks
+./build/benchmark_lsoda
+
+# Using just (runs cmake configure + build + ctest)
+just
+```
+
+## Code Formatting
+
+```bash
+clang-format -i src/LSODA.cpp src/LSODA.h
+```
+
+Style: WebKit-based, 80-column limit, 4-space indent (see `.clang-format`).
+
+## Architecture
+
+The library consists of two main files:
+
+- **`src/LSODA.h`** — Class definition with the `LSODA` class and `LSODA_ODE_SYSTEM_TYPE` function pointer typedef
+- **`src/LSODA.cpp`** — Full solver implementation (~2100 lines)
+- **`src/helper.h`** — Template utilities for float comparison (`areEqual`) and vector printing
+
+### Key API
+
+```cpp
+// ODE system function signature
+typedef void (*LSODA_ODE_SYSTEM_TYPE)(double t, double* y, double* dydt, void* data);
+
+LSODA solver;
+
+// Low-level interface
+solver.lsoda(f, neq, y, &t, tout, itol, rtol, atol, itask, &istate, iopt, jt, data);
+
+// Higher-level stepping interface
+solver.lsoda_update(f, neq, y, &t, tout, &istate, data, rtol, atol);
+```
+
+`istate` starts at 1; successful steps return 2; errors return negative values. Reset to 1 to restart integration.
+
+### Internal Structure
+
+The `LSODA` class holds all integration state as private members — this means **one instance per integration thread** (the benchmark demonstrates thread-safe parallel usage by creating a new `LSODA` instance per thread).
+
+Method selection is tracked by `meth_` (1=Adams, 2=BDF). The solver maintains coefficient tables `elco`/`tesco`/`el` and work arrays `yh_`, `wm_`, `ewt`, `savf`, `acor`.
+
+## Tests
+
+Tests are in `tests/test_LSODA.cpp` with three ODE systems:
+- Chemical kinetics (`fex`) — 3 equations, stiff
+- Van der Pol oscillator (`system_scipy`) — 2 equations, mu=1e4
+- GitHub issue #10 system (`system_github_issue_10`) — stiff with trigonometric forcing
+
+Assertions use `areEqual()` with default tolerance 1e-5.
+
+## CI
+
+GitHub Actions (`.github/workflows/cmake-multi-platform.yml`) runs on push/PR to `master` across Ubuntu (GCC + Clang) and Windows (MSVC), Release build only.
+
+## Changelog
+
+Generated with `git-cliff`. Run `git cliff` to regenerate `CHANGELOG.md` from conventional commits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ LSODA solver;
 solver.lsoda(f, neq, y, &t, tout, itol, rtol, atol, itask, &istate, iopt, jt, data);
 
 // Higher-level stepping interface
-solver.lsoda_update(f, neq, y, &t, tout, &istate, data, rtol, atol);
+solver.lsoda_update(f, neq, y, yout, &t, tout, &istate, data, rtol, atol);
 ```
 
 `istate` starts at 1; successful steps return 2; errors return negative values. Reset to 1 to restart integration.
@@ -67,12 +67,16 @@ Method selection is tracked by `meth_` (1=Adams, 2=BDF). The solver maintains co
 
 ## Tests
 
-Tests are in `tests/test_LSODA.cpp` with three ODE systems:
+Tests are in `tests/test_LSODA.cpp` and currently cover:
 - Chemical kinetics (`fex`) — 3 equations, stiff
 - Van der Pol oscillator (`system_scipy`) — 2 equations, mu=1e4
 - GitHub issue #10 system (`system_github_issue_10`) — stiff with trigonometric forcing
+- Exponential decay (`exponential_decay_rhs`) — 1 equation, analytical solution
+- Simple harmonic oscillator (`sho_rhs`) — 2 equations, analytical solution
+- Coupled decay chain (`coupled_decay_rhs`) — 3 equations, Bateman equations
+- Rational ODE (`rational_ode_rhs`) — 2 equations, analytical solution
 
-Assertions use `areEqual()` with default tolerance 1e-5.
+Assertions use the `CHECK` macro (throws `runtime_error`) which is active in both Debug and Release builds, unlike `assert()` which is disabled by `-DNDEBUG` in Release.
 
 ## CI
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,4 +66,32 @@ if(PROJECT_IS_TOP_LEVEL)
     add_test(NAME test_benchmark
         COMMAND $<TARGET_FILE:benchmark_lsoda>
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+    # Integration test: install into a temp prefix then build+run a standalone
+    # consumer that uses find_package(lsoda) to verify the full install works.
+    set(_integ_prefix "${CMAKE_CURRENT_BINARY_DIR}/integ_install")
+    set(_integ_build  "${CMAKE_CURRENT_BINARY_DIR}/integ_build")
+
+    add_test(NAME integration_install
+        COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR}
+                --prefix "${_integ_prefix}")
+    add_test(NAME integration_configure
+        COMMAND ${CMAKE_COMMAND}
+                -S "${CMAKE_SOURCE_DIR}/tests/integration"
+                -B "${_integ_build}"
+                -DCMAKE_PREFIX_PATH=${_integ_prefix}
+                -DCMAKE_BUILD_TYPE=Release)
+    add_test(NAME integration_build
+        COMMAND ${CMAKE_COMMAND} --build "${_integ_build}" --config Release)
+    # Use ctest inside the consumer build directory so the executable path is
+    # resolved correctly on all platforms (including MSVC multi-config generators).
+    add_test(NAME integration_run
+        COMMAND ${CMAKE_CTEST_COMMAND}
+                --test-dir "${_integ_build}"
+                --build-config Release
+                --output-on-failure)
+
+    set_tests_properties(integration_configure PROPERTIES DEPENDS integration_install)
+    set_tests_properties(integration_build     PROPERTIES DEPENDS integration_configure)
+    set_tests_properties(integration_run       PROPERTIES DEPENDS integration_build)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,18 @@
-cmake_minimum_required(VERSION 3.12)
-project(libsoda-cxx VERSION 0.1.2)
+cmake_minimum_required(VERSION 3.21)
+project(libsoda-cxx VERSION 0.1.2 LANGUAGES CXX)
 
-# compiler
-set(CMAKE_CXX_STANDARD 17)
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
-
-#
-# Setup clang-tidy for this project
-#
-find_program(CLANG_TIDY_EXE NAMES "clang-tidy")
-if(CLANG_TIDY_EXE)
-    set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}" "--checks=-*,cppcoreguidelines-*")
-    set(CMAKE_CXX_CLANG_TIDY_EXPORT_FIXES_DIR "${CMAKE_BINARY_DIR}/__clang-tidy-fixes")
-else()
-    message(WARNING "clang-tidy not found, continuing without linting.")
+# Clang-tidy: only in standalone builds to avoid leaking into consumers
+if(PROJECT_IS_TOP_LEVEL)
+    find_program(CLANG_TIDY_EXE NAMES "clang-tidy")
+    if(CLANG_TIDY_EXE)
+        set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}" "--checks=-*,cppcoreguidelines-*")
+        set(CMAKE_CXX_CLANG_TIDY_EXPORT_FIXES_DIR "${CMAKE_BINARY_DIR}/__clang-tidy-fixes")
+    else()
+        message(WARNING "clang-tidy not found, continuing without linting.")
+    endif()
 endif()
 
 if(MSVC)
@@ -22,27 +21,49 @@ else()
     add_compile_options(-Wall -Wextra)
 endif()
 
-# Configuration.
 add_subdirectory(src)
 
-#
-# Tests
-#
-find_package(Threads REQUIRED)
+# --- Install / export ---
 
-add_executable(test_lsoda ${CMAKE_SOURCE_DIR}/tests/test_LSODA.cpp)
-target_link_libraries(test_lsoda lsoda)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/lsodaConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
 
-add_executable(benchmark_lsoda ${CMAKE_SOURCE_DIR}/tests/benchmark_LSODA.cpp)
-target_link_libraries(benchmark_lsoda lsoda)
-target_link_libraries(benchmark_lsoda ${CMAKE_THREAD_LIBS_INIT})
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/lsodaConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/lsodaConfig.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/lsoda"
+)
 
-# Tests and benchmark
-enable_testing()
-add_test(NAME test_lsoda
-    COMMAND $<TARGET_FILE:test_lsoda>
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+install(EXPORT lsodaTargets
+    FILE      lsodaTargets.cmake
+    NAMESPACE lsoda::
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/lsoda"
+)
 
-add_test(NAME test_benchmark
-    COMMAND $<TARGET_FILE:benchmark_lsoda>
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/lsodaConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/lsodaConfigVersion.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/lsoda"
+)
+
+# --- Tests: only when building standalone ---
+if(PROJECT_IS_TOP_LEVEL)
+    find_package(Threads REQUIRED)
+
+    add_executable(test_lsoda tests/test_LSODA.cpp)
+    target_link_libraries(test_lsoda PRIVATE lsoda)
+
+    add_executable(benchmark_lsoda tests/benchmark_LSODA.cpp)
+    target_link_libraries(benchmark_lsoda PRIVATE lsoda ${CMAKE_THREAD_LIBS_INIT})
+
+    enable_testing()
+    add_test(NAME test_lsoda
+        COMMAND $<TARGET_FILE:test_lsoda>
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+    add_test(NAME test_benchmark
+        COMMAND $<TARGET_FILE:benchmark_lsoda>
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+endif()

--- a/README.md
+++ b/README.md
@@ -2,13 +2,38 @@
 
 # libsoda++
 
-This is a `c++11` port of LSODA library.  See
-[./tests/test_LSODA.cpp](tests/test_LSODA.cpp) for an example.
+C++17 port of the LSODA ODE solver. LSODA automatically switches between
+Adams (non-stiff) and BDF (stiff) integration methods with adaptive step size.
+
+## Usage
+
+```cpp
+#include "LSODA.h"
+
+void my_ode(double t, double* y, double* dydt, void* data) {
+    dydt[0] = -y[0];  // dy/dt = -y
+}
+
+LSODA solver;
+std::vector<double> y = {1.0}, yout;
+double t = 0.0;
+int istate = 1;
+solver.lsoda_update(my_ode, 1, y, yout, &t, 1.0, &istate, nullptr);
+// yout[1] holds the result (1-indexed)
+```
+
+See [tests/test_LSODA.cpp](tests/test_LSODA.cpp) for more examples.
+
+## Build
+
+```sh
+cmake -S . -B build && cmake --build build && cd build && ctest
+```
 
 ## Credits
 
-This work is based on <http://lh3lh3.users.sourceforge.net/download/lsoda.c>.
+Based on Heng Li's C port: <http://lh3lh3.users.sourceforge.net/download/lsoda.c>
 
-## Related projects
+## Related
 
-1. https://github.com/sdwfrost/liblsoda
+- https://github.com/sdwfrost/liblsoda

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Adams (non-stiff) and BDF (stiff) integration methods with adaptive step size.
 ## Usage
 
 ```cpp
-#include "LSODA.h"
+#include <lsoda/LSODA.h>
 
 void my_ode(double t, double* y, double* dydt, void* data) {
     dydt[0] = -y[0];  // dy/dt = -y
@@ -24,7 +24,40 @@ solver.lsoda_update(my_ode, 1, y, yout, &t, 1.0, &istate, nullptr);
 
 See [tests/test_LSODA.cpp](tests/test_LSODA.cpp) for more examples.
 
-## Build
+## Integration
+
+### FetchContent
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(lsoda
+    GIT_REPOSITORY https://github.com/dilawar/libsoda-cxx.git
+    GIT_TAG v0.1.2
+)
+FetchContent_MakeAvailable(lsoda)
+target_link_libraries(myapp PRIVATE lsoda::lsoda)
+```
+
+### add_subdirectory
+
+```cmake
+add_subdirectory(third_party/libsoda-cxx)
+target_link_libraries(myapp PRIVATE lsoda::lsoda)
+```
+
+### find_package (after install)
+
+```sh
+cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/usr/local
+cmake --install build
+```
+
+```cmake
+find_package(lsoda 0.1.2 REQUIRED CONFIG)
+target_link_libraries(myapp PRIVATE lsoda::lsoda)
+```
+
+## Build & test
 
 ```sh
 cmake -S . -B build && cmake --build build && cd build && ctest

--- a/cmake/lsodaConfig.cmake.in
+++ b/cmake/lsodaConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/lsodaTargets.cmake")
+
+check_required_components(lsoda)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,1 +1,20 @@
 add_library(lsoda LSODA.cpp)
+add_library(lsoda::lsoda ALIAS lsoda)
+
+target_include_directories(lsoda PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_compile_features(lsoda PUBLIC cxx_std_17)
+
+install(TARGETS lsoda
+    EXPORT  lsodaTargets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(FILES LSODA.h helper.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lsoda
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,14 @@
 add_library(lsoda LSODA.cpp)
 add_library(lsoda::lsoda ALIAS lsoda)
 
+# Mirror the installed layout (<prefix>/include/lsoda/LSODA.h) in the build
+# tree so add_subdirectory/FetchContent consumers use the same #include spelling
+# as find_package consumers: #include <lsoda/LSODA.h>
+configure_file(LSODA.h  "${CMAKE_CURRENT_BINARY_DIR}/lsoda/LSODA.h"  COPYONLY)
+configure_file(helper.h "${CMAKE_CURRENT_BINARY_DIR}/lsoda/helper.h" COPYONLY)
+
 target_include_directories(lsoda PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.21)
+project(lsoda_integration_test LANGUAGES CXX)
+
+find_package(lsoda REQUIRED CONFIG)
+
+add_executable(integration_test main.cpp)
+target_link_libraries(integration_test PRIVATE lsoda::lsoda)
+
+enable_testing()
+add_test(NAME integration_test COMMAND integration_test)

--- a/tests/integration/main.cpp
+++ b/tests/integration/main.cpp
@@ -1,0 +1,32 @@
+#include <lsoda/LSODA.h>
+#include <cmath>
+#include <stdexcept>
+#include <vector>
+
+// Simple exponential decay: dy/dt = -y, y(0)=1, solution: y(t)=exp(-t)
+static void exponential_decay(double, double* y, double* dydt, void*)
+{
+    dydt[0] = -y[0];
+}
+
+int main()
+{
+    LSODA solver;
+    std::vector<double> y = { 1.0 }, yout;
+    double t = 0.0;
+    int istate = 1;
+
+    solver.lsoda_update(exponential_decay, 1, y, yout, &t, 1.0, &istate, nullptr, 1e-8, 1e-10);
+
+    if (istate <= 0)
+        throw std::runtime_error("lsoda_update failed: istate=" + std::to_string(istate));
+
+    double expected = std::exp(-1.0);
+    double err = std::fabs(yout[1] - expected);
+    if (err > 1e-6)
+        throw std::runtime_error(
+            "result out of tolerance: got " + std::to_string(yout[1])
+            + ", expected " + std::to_string(expected));
+
+    return 0;
+}

--- a/tests/test_LSODA.cpp
+++ b/tests/test_LSODA.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <iomanip>
 #include <vector>
-#include <cassert>
 #include <chrono>
 #include <cmath>
 #include <stdexcept>
@@ -10,6 +9,16 @@
 #include "../src/helper.h"
 
 using namespace std;
+
+// Always-on check that works in both Debug and Release builds.
+#define CHECK(cond)                                                     \
+    do {                                                                \
+        if (!(cond)) {                                                  \
+            cerr << "FAILED: " #cond " (" << __FILE__ << ":"           \
+                 << __LINE__ << ")" << endl;                            \
+            throw runtime_error("assertion failed: " #cond);           \
+        }                                                               \
+    } while (0)
 
 // Describe the system.
 static void fex(double t, double* y, double* ydot, void* data)
@@ -105,7 +114,7 @@ int test_exponential_decay()
     }
 
     double expected = exp(-1.0);
-    assert(areEqual(expected, yout[1], 1e-6));
+    CHECK(areEqual(expected, yout[1], 1e-6));
     return 0;
 }
 
@@ -134,8 +143,8 @@ int test_simple_harmonic_oscillator()
     double expected_y0 = cos(omega * tout) + 0.1 / omega * sin(omega * tout);
     double expected_y1 = -omega * sin(omega * tout) + 0.1 * cos(omega * tout);
 
-    assert(areEqual(expected_y0, yout[1], 1e-5));
-    assert(areEqual(expected_y1, yout[2], 1e-5));
+    CHECK(areEqual(expected_y0, yout[1], 1e-5));
+    CHECK(areEqual(expected_y1, yout[2], 1e-5));
     return 0;
 }
 
@@ -177,9 +186,9 @@ int test_coupled_decay()
         + lmbd1 * lmbd0 * z0_0 / d10
             * (1.0 / d20 * (e0 - e2) - 1.0 / d21 * (e1 - e2));
 
-    assert(areEqual(expected_z0, yout[1], 1e-6));
-    assert(areEqual(expected_z1, yout[2], 1e-6));
-    assert(areEqual(expected_z2, yout[3], 1e-6));
+    CHECK(areEqual(expected_z0, yout[1], 1e-6));
+    CHECK(areEqual(expected_z1, yout[2], 1e-6));
+    CHECK(areEqual(expected_z2, yout[3], 1e-6));
     return 0;
 }
 
@@ -207,8 +216,8 @@ int test_rational_ode()
     double expected_y0 = tout / (tout + 10.0);
     double expected_y1 = 10.0 * tout / ((tout + 10.0) * (tout + 10.0));
 
-    assert(areEqual(expected_y0, yout[1], 1e-5));
-    assert(areEqual(expected_y1, yout[2], 1e-5));
+    CHECK(areEqual(expected_y0, yout[1], 1e-5));
+    CHECK(areEqual(expected_y1, yout[2], 1e-5));
     return 0;
 }
 
@@ -240,8 +249,8 @@ int test_github_system(void)
     }
 
     cout << res[0] << ' ' << res[1] << endl;
-    assert(areEqual(-11.94045, res[0]));
-    assert(areEqual(3.8610102, res[1]));
+    CHECK(areEqual(-11.94045, res[0]));
+    CHECK(areEqual(3.8610102, res[1]));
 
     if (istate <= 0) {
         cerr << "error istate = " << istate << endl;
@@ -327,7 +336,7 @@ int test_fex(void)
         if (err > 1e-6) {
             cerr << "FAILED: Expected " << expected[i] << ". Got " << res[i]
                  << endl;
-            assert(false);
+            throw runtime_error("test_fex: result out of tolerance");
         }
     }
 

--- a/tests/test_LSODA.cpp
+++ b/tests/test_LSODA.cpp
@@ -33,6 +33,48 @@ static void system_scipy(double t, double* y, double* ydot, void* data)
     ydot[1] = mu * (1 - y[0] * y[0]) * y[1] - y[0];
 }
 
+// Simple harmonic oscillator: dy0/dt = y1, dy1/dt = -omega^2 * y0
+// omega = 2 => analytical solution: y0(t) = cos(2t) + 0.05*sin(2t)
+static void sho_rhs(double t, double* y, double* ydot, void* data)
+{
+    (void)t;
+    (void)data;
+    ydot[0] = y[1];
+    ydot[1] = -4.0 * y[0];
+}
+
+// Radioactive decay chain: 3 species with decay constants lambda = {0.17, 0.23, 0.29}
+// dz0/dt = -0.17*z0
+// dz1/dt = -0.23*z1 + 0.17*z0
+// dz2/dt = -0.29*z2 + 0.23*z1
+static void coupled_decay_rhs(double t, double* y, double* ydot, void* data)
+{
+    (void)t;
+    (void)data;
+    ydot[0] = -0.17 * y[0];
+    ydot[1] = -0.23 * y[1] + 0.17 * y[0];
+    ydot[2] = -0.29 * y[2] + 0.23 * y[1];
+}
+
+// Exponential decay: dy/dt = -y, solution: y(t) = exp(-t)
+static void exponential_decay_rhs(double t, double* y, double* ydot, void* data)
+{
+    (void)t;
+    (void)data;
+    ydot[0] = -y[0];
+}
+
+// Rational ODE from SciPy test suite (sol_rational):
+// dy0/dt = y1 / t
+// dy1/dt = y1 * (y0 + 2*y1 - 1) / (t * (y0 - 1))
+// Analytical solution: y = (t/(t+10), 10*t/(t+10)^2)
+static void rational_ode_rhs(double t, double* y, double* ydot, void* data)
+{
+    (void)data;
+    ydot[0] = y[1] / t;
+    ydot[1] = y[1] * (y[0] + 2.0 * y[1] - 1.0) / (t * (y[0] - 1.0));
+}
+
 // This system is described here
 // https://github.com/sdwfrost/liblsoda/issues/10
 static void system_github_issue_10(
@@ -42,6 +84,132 @@ static void system_github_issue_10(
 
     ydot[0] = 9 * y[0] + 24 * y[1] + 5 * cos(t) - (1 / 3) * sin(t);
     ydot[1] = -24 * y[0] - 51 * y[1] - 95 * cos(t) + (1 / 3) * sin(t);
+}
+
+// Verify exponential decay: dy/dt = -y, y(0)=1
+// Integrates from t=0 to t=1, expected y(1) = exp(-1)
+int test_exponential_decay()
+{
+    double t = 0.0, tout = 1.0;
+    vector<double> y = { 1.0 };
+    int istate = 1;
+    LSODA lsoda;
+    vector<double> yout;
+
+    lsoda.lsoda_update(
+        exponential_decay_rhs, 1, y, yout, &t, tout, &istate, nullptr, 1e-8, 1e-10);
+
+    if (istate <= 0) {
+        cerr << "error istate = " << istate << endl;
+        throw runtime_error("test_exponential_decay failed");
+    }
+
+    double expected = exp(-1.0);
+    assert(areEqual(expected, yout[1], 1e-6));
+    return 0;
+}
+
+// Verify simple harmonic oscillator (from SciPy test suite):
+// dy0/dt = y1, dy1/dt = -4*y0
+// IC: y = {1.0, 0.1}, integrate from t=0 to t=1.09
+// Analytical: y0(t) = cos(2t) + 0.05*sin(2t)
+//             y1(t) = -2*sin(2t) + 0.1*cos(2t)
+int test_simple_harmonic_oscillator()
+{
+    double t = 0.0, tout = 1.09;
+    vector<double> y = { 1.0, 0.1 };
+    int istate = 1;
+    LSODA lsoda;
+    vector<double> yout;
+
+    lsoda.lsoda_update(
+        sho_rhs, 2, y, yout, &t, tout, &istate, nullptr, 1e-8, 1e-10);
+
+    if (istate <= 0) {
+        cerr << "error istate = " << istate << endl;
+        throw runtime_error("test_simple_harmonic_oscillator failed");
+    }
+
+    double omega = 2.0;
+    double expected_y0 = cos(omega * tout) + 0.1 / omega * sin(omega * tout);
+    double expected_y1 = -omega * sin(omega * tout) + 0.1 * cos(omega * tout);
+
+    assert(areEqual(expected_y0, yout[1], 1e-5));
+    assert(areEqual(expected_y1, yout[2], 1e-5));
+    return 0;
+}
+
+// Verify radioactive decay chain (from SciPy CoupledDecay test):
+// dz0/dt = -0.17*z0
+// dz1/dt = -0.23*z1 + 0.17*z0
+// dz2/dt = -0.29*z2 + 0.23*z1
+// IC: {5, 7, 13}, integrate from t=0 to t=0.5
+// Expected values from Bateman equations (computed analytically)
+int test_coupled_decay()
+{
+    double t = 0.0, tout = 0.5;
+    vector<double> y = { 5.0, 7.0, 13.0 };
+    int istate = 1;
+    LSODA lsoda;
+    vector<double> yout;
+
+    lsoda.lsoda_update(
+        coupled_decay_rhs, 3, y, yout, &t, tout, &istate, nullptr, 1e-8, 1e-10);
+
+    if (istate <= 0) {
+        cerr << "error istate = " << istate << endl;
+        throw runtime_error("test_coupled_decay failed");
+    }
+
+    // Bateman equations (analytical solution)
+    const double lmbd0 = 0.17, lmbd1 = 0.23, lmbd2 = 0.29;
+    const double z0_0 = 5.0, z0_1 = 7.0, z0_2 = 13.0;
+    const double d10 = lmbd1 - lmbd0; // 0.06
+    const double d21 = lmbd2 - lmbd1; // 0.06
+    const double d20 = lmbd2 - lmbd0; // 0.12
+    const double e0 = exp(-lmbd0 * tout);
+    const double e1 = exp(-lmbd1 * tout);
+    const double e2 = exp(-lmbd2 * tout);
+
+    double expected_z0 = z0_0 * e0;
+    double expected_z1 = z0_1 * e1 + z0_0 * lmbd0 / d10 * (e0 - e1);
+    double expected_z2 = z0_2 * e2 + z0_1 * lmbd1 / d21 * (e1 - e2)
+        + lmbd1 * lmbd0 * z0_0 / d10
+            * (1.0 / d20 * (e0 - e2) - 1.0 / d21 * (e1 - e2));
+
+    assert(areEqual(expected_z0, yout[1], 1e-6));
+    assert(areEqual(expected_z1, yout[2], 1e-6));
+    assert(areEqual(expected_z2, yout[3], 1e-6));
+    return 0;
+}
+
+// Verify rational ODE (from SciPy sol_rational test):
+// dy0/dt = y1/t, dy1/dt = y1*(y0 + 2*y1 - 1) / (t*(y0 - 1))
+// Analytical solution: y = (t/(t+10), 10*t/(t+10)^2)
+// Integrates from t=5 (IC = sol_rational(5)) to t=9
+int test_rational_ode()
+{
+    double t = 5.0, tout = 9.0;
+    // IC = analytical solution evaluated at t=5
+    vector<double> y = { 5.0 / 15.0, 10.0 * 5.0 / (15.0 * 15.0) };
+    int istate = 1;
+    LSODA lsoda;
+    vector<double> yout;
+
+    lsoda.lsoda_update(
+        rational_ode_rhs, 2, y, yout, &t, tout, &istate, nullptr, 1e-8, 1e-10);
+
+    if (istate <= 0) {
+        cerr << "error istate = " << istate << endl;
+        throw runtime_error("test_rational_ode failed");
+    }
+
+    double expected_y0 = tout / (tout + 10.0);
+    double expected_y1 = 10.0 * tout / ((tout + 10.0) * (tout + 10.0));
+
+    assert(areEqual(expected_y0, yout[1], 1e-5));
+    assert(areEqual(expected_y1, yout[2], 1e-5));
+    return 0;
 }
 
 int test_github_system(void)
@@ -171,28 +339,22 @@ int main(int argc, const char* argv[])
     (void)argc;
     (void)argv;
 
-    chrono::steady_clock::time_point begin = chrono::steady_clock::now();
-    test_scipy_sys();
-    chrono::steady_clock::time_point end = chrono::steady_clock::now();
-    cout << "|| Time taken (us)= "
-         << chrono::duration_cast<chrono::microseconds>(end - begin).count()
-         << endl;
+    auto run = [](const char* name, auto fn) {
+        auto begin = chrono::steady_clock::now();
+        fn();
+        auto end = chrono::steady_clock::now();
+        cout << "|| " << name << " time (us)= "
+             << chrono::duration_cast<chrono::microseconds>(end - begin).count()
+             << endl;
+    };
 
-    begin = chrono::steady_clock::now();
-    test_fex();
-    end = chrono::steady_clock::now();
-    cout << "|| Time taken (us)="
-         << chrono::duration_cast<chrono::nanoseconds>(end - begin).count()
-            / 1000
-         << endl;
-
-    begin = chrono::steady_clock::now();
-    test_github_system();
-    end = chrono::steady_clock::now();
-    cout << "|| Time taken (us)="
-         << chrono::duration_cast<chrono::nanoseconds>(end - begin).count()
-            / 1000
-         << endl;
+    run("test_scipy_sys", test_scipy_sys);
+    run("test_fex", test_fex);
+    run("test_github_system", test_github_system);
+    run("test_exponential_decay", test_exponential_decay);
+    run("test_simple_harmonic_oscillator", test_simple_harmonic_oscillator);
+    run("test_coupled_decay", test_coupled_decay);
+    run("test_rational_ode", test_rational_ode);
 
     return 0;
 }

--- a/tests/test_LSODA.cpp
+++ b/tests/test_LSODA.cpp
@@ -350,8 +350,10 @@ int main(int argc, const char* argv[])
 
     auto run = [](const char* name, auto fn) {
         auto begin = chrono::steady_clock::now();
-        fn();
+        int rc = fn();
         auto end = chrono::steady_clock::now();
+        if (rc != 0)
+            throw runtime_error(string(name) + " returned non-zero: " + to_string(rc));
         cout << "|| " << name << " time (us)= "
              << chrono::duration_cast<chrono::microseconds>(end - begin).count()
              << endl;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README updated with usage examples, build/test/install/integration guidance and refreshed credits.
  * New developer guide added with API overview, build/test/benchmark commands, coding style, and architecture notes.
  * CHANGELOG updated with unreleased entries.

* **Tests**
  * Expanded suite with exponential decay, harmonic oscillator, coupled decay, and rational ODE tests; assertions made robust and unified timing/runner output.
  * Added a CTest integration that builds and runs a consumer using the installed package.

* **Packaging**
  * CMake enhanced to produce an installable, findable package with exported targets and an imported namespace for consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->